### PR TITLE
Fix build errors related to Docker and Apple Silicon

### DIFF
--- a/streams/build.gradle
+++ b/streams/build.gradle
@@ -79,9 +79,9 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter:5.10.3')
     testRuntimeOnly('org.junit.platform:junit-platform-launcher:1.10.3')
     testImplementation "org.apache.kafka:kafka-streams-test-utils:3.6.0"
-    testImplementation 'org.testcontainers:junit-jupiter:1.20.1'
-    testImplementation 'org.testcontainers:kafka:1.20.1'
-    testImplementation 'org.testcontainers:toxiproxy:1.20.1'
+    testImplementation 'org.testcontainers:junit-jupiter:1.21.3'
+    testImplementation 'org.testcontainers:kafka:1.21.3'
+    testImplementation 'org.testcontainers:toxiproxy:1.21.3'
     testImplementation 'org.mockito:mockito-core:5.11.0'
     testImplementation 'org.hamcrest:hamcrest:2.2'
 }

--- a/streams/src/test/resources/docker-java.properties
+++ b/streams/src/test/resources/docker-java.properties
@@ -1,0 +1,1 @@
+api.version=1.44


### PR DESCRIPTION
Updates configuration to allow building on M4 Mac

Starting a Gradle Daemon (subsequent builds will be faster)

> Task :custom-connector:compileTestJava
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

> Task :custom-connector:test

bbejeck.chapter_5.connector.StockTickerSourceConnectorTest

  Test Connector should only have one config group because max.tasks is one PASSED

StockTickerSourceConnectorTest > Connector should only have one config group because max.tasks is one PASSED
  Test Connector should five config groups because max.tasks is five PASSED

StockTickerSourceConnectorTest > Connector should five config groups because max.tasks is five PASSED
  Test Connector should be assignable from base Connector PASSED

StockTickerSourceConnectorTest > Connector should be assignable from base Connector PASSED

bbejeck.chapter_5.connector.StockTickerSourceTaskTest

  Test Should retrieve actual end of day quotes PASSED

StockTickerSourceTaskTest > Should retrieve actual end of day quotes PASSED
  Test Should retrieve quotes from Yahoo feed PASSED

StockTickerSourceTaskTest > Should retrieve quotes from Yahoo feed PASSED

bbejeck.chapter_5.transformer.MultiFieldExtractTest

  Test Transforming with a schema PASSED

MultiFieldExtractTest > Transforming with a schema PASSED
  Test Transforming without a schema PASSED

MultiFieldExtractTest > Transforming without a schema PASSED
  Test Transforming should handle a SourceRecord with a null value PASSED

MultiFieldExtractTest > Transforming should handle a SourceRecord with a null value PASSED

SUCCESS: Executed 8 tests in 925ms


> Task :streams:compileJava
Note: /Users/lou/dev/kafka/kafkaStreams/KafkaStreamsInAction2ndEdition/streams/src/main/java/bbejeck/chapter_9/partitioner/WindowedStreamsPartitioner.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :streams:compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

> Task :streams:test

bbejeck.chapter_10.SensorAlertingApplicationTest

  Test SensorAggregate should emit for every five readings PASSED

SensorAlertingApplicationTest > SensorAggregate should emit for every five readings PASSED
  Test SensorAggregation should provide aggregation after punctuation and no closing entry PASSED

SensorAlertingApplicationTest > SensorAggregation should provide aggregation after punctuation and no closing entry PASSED
  Test SensorAggregation should provide aggregation of two readings PASSED

SensorAlertingApplicationTest > SensorAggregation should provide aggregation of two readings PASSED
  Test SensorAggregation should not output or store record below threshold PASSED

SensorAlertingApplicationTest > SensorAggregation should not output or store record below threshold PASSED

bbejeck.chapter_10.StockPerformanceApplicationTest

  Test Punctuate should fire once first time only - time doesn't advance PASSED

StockPerformanceApplicationTest > Punctuate should fire once first time only - time doesn't advance PASSED
  Test Punctuate should fire three times - time advances more than 10 seconds PASSED

StockPerformanceApplicationTest > Punctuate should fire three times - time advances more than 10 seconds PASSED
  Test Punctuate should fire three times - manual time advances more than 10 seconds PASSED

StockPerformanceApplicationTest > Punctuate should fire three times - manual time advances more than 10 seconds PASSED

bbejeck.chapter_10.punctuator.StockPerformancePunctuatorTest

  Test Records with correct price differential should get forwarded PASSED

StockPerformancePunctuatorTest > Records with correct price differential should get forwarded PASSED

bbejeck.chapter_14.CurrencyExchangeClientTest

  Test Should consume records and convert to correct amount PASSED

CurrencyExchangeClientTest > Should consume records and convert to correct amount PASSED

bbejeck.chapter_3.AvroProducerConsumerTest

  Test Produce Avro records but consume GenericRecords PASSED (2.5s)

AvroProducerConsumerTest > Produce Avro records but consume GenericRecords PASSED
  Test Produce and Consume Avro specific records PASSED (2.1s)

AvroProducerConsumerTest > Produce and Consume Avro specific records PASSED

bbejeck.chapter_3.JsonSchemaProduceConsumeTest

  Test Produce and Consume Json Schema PASSED (2.2s)

JsonSchemaProduceConsumeTest > Produce and Consume Json Schema PASSED
  Test Produce and Consume Json Schema Generic types PASSED (2.1s)

JsonSchemaProduceConsumeTest > Produce and Consume Json Schema Generic types PASSED

bbejeck.chapter_3.ProtobufProduceConsumeTest

  Test Produce and Consume protobuf dynamic messages PASSED (2.2s)

ProtobufProduceConsumeTest > Produce and Consume protobuf dynamic messages PASSED
  Test Produce and Consume specific protobuf types PASSED (2.1s)

ProtobufProduceConsumeTest > Produce and Consume specific protobuf types PASSED

bbejeck.chapter_4.AdminClientTest

  Test should create topics PASSED

AdminClientTest > should create topics PASSED
  Test should delete topics PASSED

AdminClientTest > should delete topics PASSED

bbejeck.chapter_4.multi_event.proto.MultiEventProtoProduceConsumeTest

  Test should produce and consume multiple events per topic PASSED

MultiEventProtoProduceConsumeTest > should produce and consume multiple events per topic PASSED

bbejeck.chapter_6.BranchTest

  Test shouldSplitStreamsNoDefault() PASSED

BranchTest > shouldSplitStreamsNoDefault() PASSED
  Test shouldSplitStreamsWithDefault() PASSED

BranchTest > shouldSplitStreamsWithDefault() PASSED

bbejeck.chapter_6.KafkaStreamsYellingAppTest

  Test Should Yell At Everyone PASSED

KafkaStreamsYellingAppTest > Should Yell At Everyone PASSED

bbejeck.chapter_7.StreamsCountingApplicationTest

  Test Should Count All Records By Key PASSED

StreamsCountingApplicationTest > Should Count All Records By Key PASSED

bbejeck.chapter_7.StreamsCountingInMemoryApplicationTest

  Test Should Count All Records By Key with In-Memory Store PASSED

StreamsCountingInMemoryApplicationTest > Should Count All Records By Key with In-Memory Store PASSED

bbejeck.chapter_7.StreamsPokerGameInMemoryStoreReducerTest

  Test Reduce multiple scores PASSED

StreamsPokerGameInMemoryStoreReducerTest > Reduce multiple scores PASSED

bbejeck.chapter_7.StreamsPokerGameReducerTest

  Test Reduce Test PASSED

StreamsPokerGameReducerTest > Reduce Test PASSED

bbejeck.chapter_7.StreamsStockTransactionAggregationsTest

  Test Should Complete Aggregations for Stock Transactions PASSED

StreamsStockTransactionAggregationsTest > Should Complete Aggregations for Stock Transactions PASSED

bbejeck.chapter_9.hopping.StreamsCountHoppingWindowIntegrationTest

  Test Integration test for hopping window PASSED (36.4s)

StreamsCountHoppingWindowIntegrationTest > Integration test for hopping window PASSED

bbejeck.chapter_9.partitioner.WindowedStreamsPartitionerTest

  Test The same keys should go to the same partition PASSED

WindowedStreamsPartitionerTest > The same keys should go to the same partition PASSED
  Test Null Windowed should result in empty partitions PASSED

WindowedStreamsPartitionerTest > Null Windowed should result in empty partitions PASSED
  Test Null keys should result in empty partitions PASSED

WindowedStreamsPartitionerTest > Null keys should result in empty partitions PASSED

bbejeck.chapter_9.sliding.PageViewSlidingWindowsTest

  Test slidingWindowTest() PASSED

PageViewSlidingWindowsTest > slidingWindowTest() PASSED

bbejeck.chapter_9.tumbling.IotStreamingAggregationTumblingWindowsTest

  Test testTumblingWindowAggregation() PASSED

IotStreamingAggregationTumblingWindowsTest > testTumblingWindowAggregation() PASSED

bbejeck.chapter_9.tumbling.StreamsCountTumblingWindowSuppressedEagerTest

  Test Topology should output count when number keys exceeds 50 PASSED (1.2s)

StreamsCountTumblingWindowSuppressedEagerTest > Topology should output count when number keys exceeds 50 PASSED
  Test Topology should output count when window closes PASSED

StreamsCountTumblingWindowSuppressedEagerTest > Topology should output count when window closes PASSED

bbejeck.serializers.JsonSerializerDeserializerTest

  Test Should round-trip a POJO object PASSED

JsonSerializerDeserializerTest > Should round-trip a POJO object PASSED
  Test Should round-trip a hash map PASSED

JsonSerializerDeserializerTest > Should round-trip a hash map PASSED

bbejeck.serializers.ProtoSerializerDeserializerTest

  Test Should Round trip a Proto object PASSED

ProtoSerializerDeserializerTest > Should Round trip a Proto object PASSED

SUCCESS: Executed 37 tests in 58.9s


BUILD SUCCESSFUL in 1m 15s
64 actionable tasks: 64 executed